### PR TITLE
Changing the location of the gen.cs file

### DIFF
--- a/Discord QuickEdit.csproj
+++ b/Discord QuickEdit.csproj
@@ -15,10 +15,12 @@
     <PackageReference Include="FFMpegCore" Version="5.1.0" />
   </ItemGroup>
 
-	<Target Name="Date" BeforeTargets="BeforeBuild">
-		<WriteLinesToFile File="$(IntermediateOutputPath)gen.cs" Lines="static partial class Builtin { public static long CompileTime = $([System.DateTime]::UtcNow.Ticks) %3B }" Overwrite="true" />
-		<ItemGroup>
-			<Compile Include="$(IntermediateOutputPath)gen.cs" />
-		</ItemGroup>
-	</Target>
+  <Target Name="Date" BeforeTargets="BeforeBuild">
+	  <WriteLinesToFile
+		File="GeneratedFiles\gen.cs"
+		Lines="static partial class Builtin { public static long CompileTime = $([System.DateTime]::UtcNow.Ticks) %3B }"
+		Overwrite="true" />
+	  <Message Importance="high" Text="Generated file: GeneratedFiles\gen.cs" />
+  </Target>
+
 </Project>

--- a/Discord QuickEdit.csproj
+++ b/Discord QuickEdit.csproj
@@ -18,7 +18,7 @@
   <Target Name="Date" BeforeTargets="BeforeBuild">
 	  <WriteLinesToFile
 		File="GeneratedFiles\gen.cs"
-		Lines="static partial class Builtin { public static long CompileTime = $([System.DateTime]::UtcNow.Ticks) %3B }"
+		Lines="namespace QuickEdit { static partial class Builtin { public static long CompileTime = $([System.DateTime]::UtcNow.Ticks) %3B  } }"
 		Overwrite="true" />
 	  <Message Importance="high" Text="Generated file: GeneratedFiles\gen.cs" />
   </Target>

--- a/Discord QuickEdit.csproj
+++ b/Discord QuickEdit.csproj
@@ -15,11 +15,12 @@
     <PackageReference Include="FFMpegCore" Version="5.1.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="GeneratedFiles\" />
+  </ItemGroup>
+
   <Target Name="Date" BeforeTargets="BeforeBuild">
-	  <WriteLinesToFile
-		File="GeneratedFiles\gen.cs"
-		Lines="namespace QuickEdit { static partial class Builtin { public static long CompileTime = $([System.DateTime]::UtcNow.Ticks) %3B  } }"
-		Overwrite="true" />
+	  <WriteLinesToFile File="GeneratedFiles\gen.cs" Lines="namespace QuickEdit%3B static partial class Builtin { public static long CompileTime = $([System.DateTime]::UtcNow.Ticks) %3B }" Overwrite="true" />
 	  <Message Importance="high" Text="Generated file: GeneratedFiles\gen.cs" />
   </Target>
 

--- a/GeneratedFiles/gen.cs
+++ b/GeneratedFiles/gen.cs
@@ -1,1 +1,1 @@
-namespace QuickEdit; static partial class Builtin { public static long CompileTime = 638571590610704332 ; }
+namespace QuickEdit; static partial class Builtin { public static long CompileTime = 638_571_590_610_704_332 ; }

--- a/GeneratedFiles/gen.cs
+++ b/GeneratedFiles/gen.cs
@@ -1,1 +1,1 @@
-namespace QuickEdit { static partial class Builtin { public static long CompileTime = 638571577051546842 ;  } }
+namespace QuickEdit; static partial class Builtin { public static long CompileTime = 638571590610704332 ; }

--- a/GeneratedFiles/gen.cs
+++ b/GeneratedFiles/gen.cs
@@ -1,0 +1,1 @@
+static partial class Builtin { public static long CompileTime = 638571569054106431 ; }

--- a/GeneratedFiles/gen.cs
+++ b/GeneratedFiles/gen.cs
@@ -1,1 +1,1 @@
-static partial class Builtin { public static long CompileTime = 638571569054106431 ; }
+namespace QuickEdit { static partial class Builtin { public static long CompileTime = 638571577051546842 ;  } }


### PR DESCRIPTION
Previously, your .csproj file was configured to create a gen.cs file. at the intermediate level ( Debug/.net/... ). Therefore, Visual Studio (possible problem with other code editors) cannot include the gen.cs file in the assembly. Because of this, I did not have the Builtin class (CS0246). So I moved the gen.cs file to the project root folder.