### PR TITLE
Changing the location of the gen.cs file 

### DIFF
--- a/Discord QuickEdit.csproj
+++ b/Discord QuickEdit.csproj
@@ -1,24 +1,29 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
-    <RootNamespace>QuickEdit</RootNamespace>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-    <AssemblyName>quickedit</AssemblyName>
-    <AssemblyVersion>0.0.0.0</AssemblyVersion>
-  </PropertyGroup>
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net8.0</TargetFramework>
+		<RootNamespace>QuickEdit</RootNamespace>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<AssemblyName>quickedit</AssemblyName>
+		<AssemblyVersion>0.0.0.0</AssemblyVersion>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Discord.Net" Version="3.15.2" />
-    <PackageReference Include="FFMpegCore" Version="5.1.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Discord.Net" Version="3.15.2" />
+		<PackageReference Include="FFMpegCore" Version="5.1.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Folder Include="GeneratedFiles\" />
+	</ItemGroup>
 
 	<Target Name="Date" BeforeTargets="BeforeBuild">
-		<WriteLinesToFile File="$(IntermediateOutputPath)gen.cs" Lines="static partial class Builtin { public static long CompileTime = $([System.DateTime]::UtcNow.Ticks) %3B }" Overwrite="true" />
-		<ItemGroup>
-			<Compile Include="$(IntermediateOutputPath)gen.cs" />
-		</ItemGroup>
+		<WriteLinesToFile
+			File="GeneratedFiles\gen.cs"
+			Lines="namespace QuickEdit { static partial class Builtin { public static long CompileTime = $([System.DateTime]::UtcNow.Ticks) %3B } }"
+			Overwrite="true" />
+		<Message Importance="high" Text="Generated file: GeneratedFiles\gen.cs" />
 	</Target>
 </Project>

--- a/GeneratedFiles/gen.cs
+++ b/GeneratedFiles/gen.cs
@@ -1,0 +1,1 @@
+namespace QuickEdit { static partial class Builtin { public static long CompileTime = 638571716455080101 ; } }

--- a/GeneratedFiles/gen.cs
+++ b/GeneratedFiles/gen.cs
@@ -1,1 +1,2 @@
-namespace QuickEdit { static partial class Builtin { public static long CompileTime = 638571716455080101 ; } }
+namespace QuickEdit; 
+static partial class Builtin { public static long CompileTime = 638_571_716_455_080_101 ; } 


### PR DESCRIPTION
Previously, your .csproj file was configured to create a gen.cs file. at the intermediate level ( Debug/.net/... ). Therefore, Visual Studio (possible problem with other code editors) cannot include the gen.cs file in the assembly. Because of this, I did not have the Builtin class (CS0246). So I moved the gen.cs file to the project root folder.